### PR TITLE
codegen hotfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ testem.log
 /typings
 .env*
 migrations.json
+.npmrc
 
 # System Files
 .DS_Store

--- a/libs/kjd/feature-blog/codegen.ts
+++ b/libs/kjd/feature-blog/codegen.ts
@@ -16,7 +16,7 @@ const config: CodegenConfig = {
     'libs/kjd/feature-blog/src/lib/generated/': {
       preset: 'client',
       presetConfig: {
-        fragmentMasking: { unmaskFunctionName: 'fragmentData' },
+        fragmentMasking: { unmaskFunctionName: 'unmaskFragment' },
       },
     },
   },

--- a/libs/kjd/feature-blog/src/lib/generated/fragment-masking.ts
+++ b/libs/kjd/feature-blog/src/lib/generated/fragment-masking.ts
@@ -15,26 +15,26 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
   : never;
 
 // return non-nullable if `fragmentType` is non-nullable
-export function fragmentData<TType>(
+export function unmaskFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: FragmentType<DocumentTypeDecoration<TType, any>>
 ): TType;
 // return nullable if `fragmentType` is nullable
-export function fragmentData<TType>(
+export function unmaskFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null | undefined
 ): TType | null | undefined;
 // return array of non-nullable if `fragmentType` is array of non-nullable
-export function fragmentData<TType>(
+export function unmaskFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>
 ): ReadonlyArray<TType>;
 // return array of nullable if `fragmentType` is array of nullable
-export function fragmentData<TType>(
+export function unmaskFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
 ): ReadonlyArray<TType> | null | undefined;
-export function fragmentData<TType>(
+export function unmaskFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
 ): TType | ReadonlyArray<TType> | null | undefined {

--- a/libs/kjd/feature-home/codegen.ts
+++ b/libs/kjd/feature-home/codegen.ts
@@ -16,7 +16,7 @@ const config: CodegenConfig = {
     'libs/kjd/feature-home/src/lib/generated/': {
       preset: 'client',
       presetConfig: {
-        fragmentMasking: { unmaskFunctionName: 'fragmentData' },
+        fragmentMasking: { unmaskFunctionName: 'unmaskFragment' },
       },
     },
   },

--- a/libs/kjd/feature-home/src/lib/generated/fragment-masking.ts
+++ b/libs/kjd/feature-home/src/lib/generated/fragment-masking.ts
@@ -15,26 +15,26 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
   : never;
 
 // return non-nullable if `fragmentType` is non-nullable
-export function fragmentData<TType>(
+export function unmaskFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: FragmentType<DocumentTypeDecoration<TType, any>>
 ): TType;
 // return nullable if `fragmentType` is nullable
-export function fragmentData<TType>(
+export function unmaskFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null | undefined
 ): TType | null | undefined;
 // return array of non-nullable if `fragmentType` is array of non-nullable
-export function fragmentData<TType>(
+export function unmaskFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>
 ): ReadonlyArray<TType>;
 // return array of nullable if `fragmentType` is array of nullable
-export function fragmentData<TType>(
+export function unmaskFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
 ): ReadonlyArray<TType> | null | undefined;
-export function fragmentData<TType>(
+export function unmaskFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
 ): TType | ReadonlyArray<TType> | null | undefined {

--- a/libs/kjd/ui-fragments/codegen.ts
+++ b/libs/kjd/ui-fragments/codegen.ts
@@ -16,7 +16,7 @@ const config: CodegenConfig = {
     'libs/kjd/ui-fragments/src/lib/generated/': {
       preset: 'client',
       presetConfig: {
-        fragmentMasking: { unmaskFunctionName: 'fragmentData' },
+        fragmentMasking: { unmaskFunctionName: 'unmaskFragment' },
       },
     },
   },

--- a/libs/kjd/ui-fragments/src/lib/generated/fragment-masking.ts
+++ b/libs/kjd/ui-fragments/src/lib/generated/fragment-masking.ts
@@ -15,26 +15,26 @@ export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>>
   : never;
 
 // return non-nullable if `fragmentType` is non-nullable
-export function fragmentData<TType>(
+export function unmaskFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: FragmentType<DocumentTypeDecoration<TType, any>>
 ): TType;
 // return nullable if `fragmentType` is nullable
-export function fragmentData<TType>(
+export function unmaskFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null | undefined
 ): TType | null | undefined;
 // return array of non-nullable if `fragmentType` is array of non-nullable
-export function fragmentData<TType>(
+export function unmaskFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>
 ): ReadonlyArray<TType>;
 // return array of nullable if `fragmentType` is array of nullable
-export function fragmentData<TType>(
+export function unmaskFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
 ): ReadonlyArray<TType> | null | undefined;
-export function fragmentData<TType>(
+export function unmaskFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
 ): TType | ReadonlyArray<TType> | null | undefined {

--- a/libs/kjd/ui-fragments/src/lib/server/article-author/article-author.tsx
+++ b/libs/kjd/ui-fragments/src/lib/server/article-author/article-author.tsx
@@ -1,5 +1,5 @@
 import { SectionLayout } from '@nxify/kjd-ui-layout';
-import { FragmentType, fragmentData, graphql } from '../../generated';
+import { FragmentType, unmaskFragment, graphql } from '../../generated';
 
 export const ArticleAuthorFragment = graphql(`
   fragment ArticleAuthorFragment on Article {
@@ -18,7 +18,7 @@ export interface ArticleAuthorProps {
 }
 
 export function ArticleAuthor({ data }: ArticleAuthorProps) {
-  const { author } = fragmentData(ArticleAuthorFragment, data);
+  const { author } = unmaskFragment(ArticleAuthorFragment, data);
 
   return (
     <SectionLayout className="flex flex-col md:flex-row gap-8 items-center md:items-start prose-headings:mt-0 prose-img:m-0">

--- a/libs/kjd/ui-fragments/src/lib/server/article-content/article-content.tsx
+++ b/libs/kjd/ui-fragments/src/lib/server/article-content/article-content.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { FragmentType, fragmentData, graphql } from '../../generated';
+import { FragmentType, unmaskFragment, graphql } from '../../generated';
 import { ArticleHero } from '../article-hero/article-hero';
 import { ArticleMarkdown } from '../article-markdown/article-markdown';
 import { ArticleAuthor } from '../article-author/article-author';
@@ -19,7 +19,7 @@ export interface ArticleContentProps {
 }
 
 export function ArticleContent({ data }: ArticleContentProps) {
-  const { article } = fragmentData(ArticleContentQueryFragment, data);
+  const { article } = unmaskFragment(ArticleContentQueryFragment, data);
 
   if (!article) {
     return notFound();

--- a/libs/kjd/ui-fragments/src/lib/server/article-explorer-section/article-explorer-section.tsx
+++ b/libs/kjd/ui-fragments/src/lib/server/article-explorer-section/article-explorer-section.tsx
@@ -1,5 +1,5 @@
 import { SectionLayout } from '@nxify/kjd-ui-layout';
-import { FragmentType, fragmentData, graphql } from '../../generated';
+import { FragmentType, unmaskFragment, graphql } from '../../generated';
 import { ArticleExplorer } from '../article-explorer/article-explorer';
 
 const ArticleExplorerSectionFragment = graphql(`
@@ -20,7 +20,7 @@ export function ArticleExplorerSection({ data }: ArticleExplorerSectionProps) {
     return null;
   }
 
-  const fragment = fragmentData(ArticleExplorerSectionFragment, data);
+  const fragment = unmaskFragment(ArticleExplorerSectionFragment, data);
 
   return (
     <SectionLayout>

--- a/libs/kjd/ui-fragments/src/lib/server/article-hero/article-hero.tsx
+++ b/libs/kjd/ui-fragments/src/lib/server/article-hero/article-hero.tsx
@@ -1,4 +1,4 @@
-import { FragmentType, fragmentData, graphql } from '../../generated';
+import { FragmentType, unmaskFragment, graphql } from '../../generated';
 import { format, parseISO } from 'date-fns';
 import { Markdown } from '@nxify/kjd-ui-layout';
 
@@ -21,7 +21,7 @@ export interface ArticleHeroProps {
 }
 
 export function ArticleHero({ data }: ArticleHeroProps) {
-  const { createdAt, hero } = fragmentData(ArticleHeroFragment, data);
+  const { createdAt, hero } = unmaskFragment(ArticleHeroFragment, data);
 
   return (
     <header className="bg-neutral-700 max-w-none">

--- a/libs/kjd/ui-fragments/src/lib/server/article-markdown/article-markdown.tsx
+++ b/libs/kjd/ui-fragments/src/lib/server/article-markdown/article-markdown.tsx
@@ -1,5 +1,5 @@
 import { Markdown, SectionLayout } from '@nxify/kjd-ui-layout';
-import { FragmentType, fragmentData, graphql } from '../../generated';
+import { FragmentType, unmaskFragment, graphql } from '../../generated';
 
 export const ArticleMarkdownFragment = graphql(`
   fragment ArticleMarkdownFragment on Article {
@@ -12,7 +12,7 @@ export interface ArticleMarkdownProps {
 }
 
 export function ArticleMarkdown({ data }: ArticleMarkdownProps) {
-  const { markdown } = fragmentData(ArticleMarkdownFragment, data);
+  const { markdown } = unmaskFragment(ArticleMarkdownFragment, data);
 
   return (
     <SectionLayout>

--- a/libs/kjd/ui-fragments/src/lib/server/article-preview/article-preview.tsx
+++ b/libs/kjd/ui-fragments/src/lib/server/article-preview/article-preview.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { FragmentType, fragmentData, graphql } from '../../generated';
+import { FragmentType, unmaskFragment, graphql } from '../../generated';
 import { format, parseISO } from 'date-fns';
 import { Markdown } from '@nxify/kjd-ui-layout';
 
@@ -24,7 +24,10 @@ export interface ArticlePreviewProps {
 }
 
 export function ArticlePreview({ data }: ArticlePreviewProps) {
-  const { createdAt, hero, slug } = fragmentData(ArticlePreviewFragment, data);
+  const { createdAt, hero, slug } = unmaskFragment(
+    ArticlePreviewFragment,
+    data
+  );
 
   return (
     <article className="prose-headings:font-light prose-headings:mt-0 prose-p:mb-0 border-neutral-700 last-of-type:border-transparent border-b py-8 first-of-type:pt-0 last-of-type:pb-0 lg:py-16">

--- a/libs/kjd/ui-fragments/src/lib/server/page-content/page-content.tsx
+++ b/libs/kjd/ui-fragments/src/lib/server/page-content/page-content.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { FragmentType, fragmentData, graphql } from '../../generated';
+import { FragmentType, unmaskFragment, graphql } from '../../generated';
 import { PageHero } from '../page-hero/page-hero';
 import { PageSectionExplorer } from '../page-section-explorer/page-section-explorer';
 
@@ -18,7 +18,7 @@ export interface PageContentProps {
 }
 
 export function PageContent({ data, variant }: PageContentProps) {
-  const { page } = fragmentData(PageContentQueryFragment, data);
+  const { page } = unmaskFragment(PageContentQueryFragment, data);
 
   if (!page) {
     return notFound();

--- a/libs/kjd/ui-fragments/src/lib/server/page-hero/page-hero.tsx
+++ b/libs/kjd/ui-fragments/src/lib/server/page-hero/page-hero.tsx
@@ -1,4 +1,4 @@
-import { FragmentType, fragmentData, graphql } from '../../generated';
+import { FragmentType, unmaskFragment, graphql } from '../../generated';
 import { Markdown } from '@nxify/kjd-ui-layout';
 
 const PageHeroFragment = graphql(`
@@ -35,7 +35,7 @@ export interface PageHeroProps {
 }
 
 export function PageHero({ data, variant = 'page' }: PageHeroProps) {
-  const { hero } = fragmentData(PageHeroFragment, data);
+  const { hero } = unmaskFragment(PageHeroFragment, data);
 
   return (
     <header className="bg-neutral-700 max-w-none">

--- a/libs/kjd/ui-fragments/src/lib/server/page-section-explorer/page-section-explorer.tsx
+++ b/libs/kjd/ui-fragments/src/lib/server/page-section-explorer/page-section-explorer.tsx
@@ -1,5 +1,5 @@
 import { ElementType } from 'react';
-import { FragmentType, fragmentData, graphql } from '../../generated';
+import { FragmentType, unmaskFragment, graphql } from '../../generated';
 import { ArticleExplorerSection } from '../article-explorer-section/article-explorer-section';
 
 const PageSectionExplorerFragment = graphql(`
@@ -20,7 +20,7 @@ export interface PageSectionExplorerProps {
 }
 
 export function PageSectionExplorer({ data }: PageSectionExplorerProps) {
-  const { sections } = fragmentData(PageSectionExplorerFragment, data);
+  const { sections } = unmaskFragment(PageSectionExplorerFragment, data);
 
   return sections.map((fragment, index) => {
     const Component = SECTIONS[fragment.__typename];

--- a/libs/nxify-io/graphql-codegen/src/generators/configuration/files/codegen.__ts__
+++ b/libs/nxify-io/graphql-codegen/src/generators/configuration/files/codegen.__ts__
@@ -6,11 +6,8 @@ const { <%= schema %> } = process.env;
 <% } %>
 
 const config: CodegenConfig = {
-  <% if (schemaIsEnvironmentVariable) { %>
-  schema: <%= schema %>,
-  <% } else { %>
-  schema: '<%= schema %>',
-  <% } %>documents: [
+  schema: <%- schemaIsEnvironmentVariable ? schema : `"${schema}"` %>,
+  documents: [
     ...createGlobPatternsForDependencies(
       __dirname,
       'lib/{client,server}/**/*!(*.stories|*.spec).{ts,tsx}'

--- a/libs/nxify-io/graphql-codegen/src/generators/configuration/files/codegen.__ts__
+++ b/libs/nxify-io/graphql-codegen/src/generators/configuration/files/codegen.__ts__
@@ -1,12 +1,12 @@
 import { CodegenConfig } from '@graphql-codegen/cli';
 import { createGlobPatternsForDependencies } from '@nx/js/src/utils/generate-globs';
 
-<% if (schemaIsEnvironmentVariable) { %>
+<% if (!schemaIsPathOrURL) { %>
 const { <%= schema %> } = process.env;
 <% } %>
 
 const config: CodegenConfig = {
-  schema: <%- schemaIsEnvironmentVariable ? schema : `"${schema}"` %>,
+  schema: <%- schemaIsPathOrURL ? `"${schema}"` : schema %>,
   documents: [
     ...createGlobPatternsForDependencies(
       __dirname,
@@ -19,7 +19,7 @@ const config: CodegenConfig = {
       <% if (!skipClientPreset) { %>
       preset: 'client',
       presetConfig: {
-        fragmentMasking: { unmaskFunctionName: 'fragmentData' },
+        fragmentMasking: { unmaskFunctionName: '<%= unmaskFunctionName %>' },
       },
       <% } %>
     },

--- a/libs/nxify-io/graphql-codegen/src/generators/configuration/generator.spec.ts
+++ b/libs/nxify-io/graphql-codegen/src/generators/configuration/generator.spec.ts
@@ -43,7 +43,7 @@ describe('configuration generator', () => {
           'mylib/src/lib/generated/': {
             preset: 'client',
             presetConfig: {
-              fragmentMasking: { unmaskFunctionName: 'fragmentData' },
+              fragmentMasking: { unmaskFunctionName: 'unmaskFragment' },
             },
           },
         },

--- a/libs/nxify-io/graphql-codegen/src/generators/configuration/generator.ts
+++ b/libs/nxify-io/graphql-codegen/src/generators/configuration/generator.ts
@@ -15,17 +15,19 @@ export function normalizeOptions(
     outputPath = 'src/lib/generated/',
     schema = 'SCHEMA_ENDPOINT',
     skipClientPreset = false,
+    unmaskFunctionName = 'unmaskFragment',
     ...rest
   }: ConfigurationGeneratorSchema
 ): ConfigurationGeneratorSchema {
   const project = readProjectConfiguration(tree, rest.project);
-  const schemaIsEnvironmentVariable = !isPathOrUrlLike(schema);
+  const schemaIsPathOrURL = isPathOrUrlLike(schema);
 
   return {
     outputPath: ensureTrailingSlash(project.root, outputPath),
     schema,
-    schemaIsEnvironmentVariable,
+    schemaIsPathOrURL,
     skipClientPreset,
+    unmaskFunctionName,
     ...rest,
   };
 }
@@ -41,7 +43,7 @@ function ensureTrailingSlash(...paths: string[]) {
 }
 
 function isPathOrUrlLike(value: string) {
-  if (value.includes('/')) {
+  if (value.startsWith('http') || value.includes(sep)) {
     return true;
   }
 

--- a/libs/nxify-io/graphql-codegen/src/generators/configuration/schema.d.ts
+++ b/libs/nxify-io/graphql-codegen/src/generators/configuration/schema.d.ts
@@ -2,7 +2,8 @@ export interface ConfigurationGeneratorSchema {
   outputPath?: string;
   project: string;
   schema?: string;
-  schemaIsEnvironmentVariable?: boolean;
+  schemaIsPathOrURL?: boolean;
   skipClientPreset?: boolean;
   skipValidation?: boolean;
+  unmaskFunctionName?: string;
 }

--- a/libs/nxify-io/graphql-codegen/src/generators/configuration/schema.json
+++ b/libs/nxify-io/graphql-codegen/src/generators/configuration/schema.json
@@ -20,6 +20,11 @@
       "description": "The location where code is generated relative to the project root. Defaults to `src/lib/generated/`.",
       "default": "src/lib/generated"
     },
+    "unmaskFunctionName": {
+      "type": "string",
+      "description": "Name of the generated unmask function. Defaults to `unmaskFragment`.",
+      "default": "unmaskFragment"
+    },
     "schema": {
       "type": "string",
       "description": "The schema location as an environment variable or URL. Defaults to `SCHEMA_ENDPOINT`.",

--- a/libs/nxify-io/graphql-codegen/src/generators/init/generator.spec.ts
+++ b/libs/nxify-io/graphql-codegen/src/generators/init/generator.spec.ts
@@ -2,7 +2,11 @@ import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { Tree, readJson, writeJson } from '@nx/devkit';
 
 import { initGenerator } from './generator';
-import { cliVersion, clinetPresetVersion } from '../../lib/versions';
+import {
+  cliVersion,
+  clinetPresetVersion,
+  graphqlVersion,
+} from '../../lib/versions';
 
 describe('init generator', () => {
   let tree: Tree;
@@ -16,6 +20,10 @@ describe('init generator', () => {
     await initGenerator(tree, {});
 
     const packageJson = readJson(tree, 'package.json');
+
+    expect(packageJson.dependencies).toEqual({
+      graphql: graphqlVersion,
+    });
 
     expect(packageJson.devDependencies).toEqual({
       '@graphql-codegen/cli': cliVersion,

--- a/libs/nxify-io/graphql-codegen/src/generators/init/generator.ts
+++ b/libs/nxify-io/graphql-codegen/src/generators/init/generator.ts
@@ -1,6 +1,10 @@
 import { addDependenciesToPackageJson, formatFiles, Tree } from '@nx/devkit';
 import { InitGeneratorSchema } from './schema';
-import { clinetPresetVersion, cliVersion } from '../../lib/versions';
+import {
+  clinetPresetVersion,
+  cliVersion,
+  graphqlVersion,
+} from '../../lib/versions';
 
 export async function initGenerator(
   tree: Tree,
@@ -8,7 +12,7 @@ export async function initGenerator(
 ) {
   const task = addDependenciesToPackageJson(
     tree,
-    {},
+    { graphql: graphqlVersion },
     {
       '@graphql-codegen/cli': cliVersion,
       '@graphql-codegen/client-preset': clinetPresetVersion,

--- a/libs/nxify-io/graphql-codegen/src/lib/versions.ts
+++ b/libs/nxify-io/graphql-codegen/src/lib/versions.ts
@@ -1,2 +1,3 @@
 export const cliVersion = '5.0.0';
 export const clinetPresetVersion = '4.1.0';
+export const graphqlVersion = '16.8.0';

--- a/tools/scripts/publish.mjs
+++ b/tools/scripts/publish.mjs
@@ -62,7 +62,7 @@ try {
 
 // Execute "npm publish" to publish
 execSync(
-  `export NPM_TOKEN=${process.env.NPM_TOKEN} npm publish ${outputPath} --access public --tag ${tag}`,
+  `export NPM_TOKEN=${process.env.NPM_TOKEN} npm publish ${outputPath} --access=public --tag=${tag}`,
   {
     stdio: 'inherit',
   }

--- a/tools/scripts/publish.mjs
+++ b/tools/scripts/publish.mjs
@@ -62,7 +62,7 @@ try {
 
 // Execute "npm publish" to publish
 execSync(
-  `export NPM_TOKEN=${process.env.NPM_TOKEN} npm publish ${outputPath} --access=public --tag=${tag}`,
+  `npm publish ${outputPath} --access=public --registry=https://registry.npmjs.org --tag=${tag}`,
   {
     stdio: 'inherit',
   }


### PR DESCRIPTION
- Fix the `configuration` generator output when `schema` is a path or URL like value
- Default the unmask function name to `unmaskFragment`
- Update internal unmask function names to `unmaskFragment`