### PR TITLE
heading styling in article pages

### DIFF
--- a/libs/kjd/ui-fragments/src/lib/server/article-markdown/article-markdown.tsx
+++ b/libs/kjd/ui-fragments/src/lib/server/article-markdown/article-markdown.tsx
@@ -16,7 +16,7 @@ export function ArticleMarkdown({ data }: ArticleMarkdownProps) {
 
   return (
     <SectionLayout>
-      <Markdown className="prose-headings:font-light prose-headings:text-violet-300 prose-h3:font-bold prose-h3:text-neutral-300 prose-h3:text-lg prose-h3:uppercase">
+      <Markdown className="prose-headings:font-medium prose-headings:text-neutral-100 prose-h3:font-bold prose-h3:text-neutral-300 prose-h3:text-lg prose-h3:uppercase">
         {markdown}
       </Markdown>
     </SectionLayout>


### PR DESCRIPTION
- change headings in articles to be medium and mostly white